### PR TITLE
Feature: Add auto release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: test
+name: Test and lint
 
 on:
   push:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,9 +22,15 @@ jobs:
       - name: Build the project
         run: uv build
 
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=version::$(grep -Po 'version = "\K.+(?=")' pyproject.toml)
+
       - name: Create a Release
         uses: softprops/action-gh-release@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.sha }}
+          tag_name: v${{ steps.get_version.outputs.version }}
           generate_release_notes: true
           files: ./dist/*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,6 @@
 on:
   push:
-    # branches: [main]
+    branches: [main]
 
 name: Create Release
 
@@ -24,7 +24,9 @@ jobs:
 
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=version::$(grep -Po 'version = "\K.+(?=")' pyproject.toml)
+        run: |
+          version=$(grep -Po 'version = "\K.+(?=")' pyproject.toml)
+          echo "version=$version" >> $GITHUB_OUTPUT
 
       - name: Create a Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,6 @@ jobs:
       - name: Create a Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref }}
+          tag_name: ${{ github.sha }}
           generate_release_notes: true
           files: ./dist/*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,42 @@
+on:
+  push:
+    # branches: [main]
+
+name: Create Release
+
+jobs:
+  build:
+    name: Create Rlease
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: '3.13'
+
+      - name: Build the project
+        run: uv build
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+      - name: Upload release asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_path: ./dist/*
+          asset_content_type: application/octet-stream

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,4 +23,6 @@ jobs:
       - name: Create a Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ github.ref }}
+          generate_release_notes: true
           files: ./dist/*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,8 @@ jobs:
   build:
     name: Create Rlease
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,23 +20,7 @@ jobs:
       - name: Build the project
         run: uv build
 
-      - name: Create Release
-        id: create_release
-        uses: comnoco/create-release@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+      - name: Create a Release
+        uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: false
-          prerelease: false
-
-      - name: Upload release asset
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: ./dist/*
-          asset_content_type: application/octet-stream
+          files: ./dist/*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
+        uses: comnoco/create-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "acat"
-version = "0.2.0"
+version = "0.2.1"
 description = "Adrian Carreno's AWS Toolkit"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
# Automated Release Workflow and Version Bump

## Changes

- Renamed CI workflow from "test" to "Test and lint" for better clarity
- Added new GitHub Actions workflow for automated releases:
  - Triggers on pushes to main branch
  - Uses uv to build the Python package
  - Extracts version from `pyproject.toml` (needs to be improved)
  - Creates a tagged GitHub release with auto-generated release notes
  - Attaches build artifacts from the dist directory
- Bumped package version from 0.2.0 to 0.2.1

This PR adds automated release creation to streamline the publishing process. When code is merged to main, a new GitHub release will be automatically created with the proper version tag and distribution files attached.