### PR TITLE
Feature: Enhanced AWS SSM Parameter Management in ACAT

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "acat"
-version = "0.3.0"
+version = "0.4.0"
 description = "Adrian Carreno's AWS Toolkit"
 readme = "README.md"
 authors = [

--- a/src/acat/logger.py
+++ b/src/acat/logger.py
@@ -11,7 +11,7 @@ class PropagateHandler(logging.Handler):
 
 
 # Re-add the stderr handler with the appropriate level
-log_level = os.getenv("LOG_LEVEL", logging.WARNING)
+log_level = os.getenv("LOG_LEVEL", logging.INFO)
 logger.remove()
 logger.add(sys.stderr, level=log_level)
 

--- a/src/acat/ssm/core.py
+++ b/src/acat/ssm/core.py
@@ -1,7 +1,7 @@
 import boto3
 import click
-from loguru import logger
 
+from acat.logger import logger
 from acat.ssm.types import Parameter
 from acat.ssm.utils import get_current_params
 from acat.ssm.utils import get_ssm_parameter_names

--- a/src/acat/ssm/core.py
+++ b/src/acat/ssm/core.py
@@ -6,6 +6,7 @@ import click
 
 from acat.logger import logger
 from acat.ssm.types import Parameter
+from acat.ssm.utils import create_ssm_parameters
 from acat.ssm.utils import get_current_params
 from acat.ssm.utils import get_ssm_parameter_names
 from acat.ssm.utils import get_ssm_parameters
@@ -101,7 +102,6 @@ def copy(source: str, destination: str, overwrite: bool, replace: Optional[str])
     overwritten depending on the value of the `overwrite` flag.
     """
     logger.info(f"Copying parameters from {source} to {destination}")
-    client = boto3.client("ssm")
 
     source_params = get_ssm_parameters(source)
     logger.debug(f"Found {len(source_params)} parameters in {source}")
@@ -155,6 +155,4 @@ def copy(source: str, destination: str, overwrite: bool, replace: Optional[str])
         click.echo("Aborted")
         exit(1)
 
-    for parameter in new_params:
-        click.echo(f"Creating parameter: {parameter['Name']}")
-        client.put_parameter(Overwrite=overwrite, **parameter)
+    create_ssm_parameters(new_params, overwrite)

--- a/src/acat/ssm/utils.py
+++ b/src/acat/ssm/utils.py
@@ -3,10 +3,10 @@ from typing import Sequence
 from typing import Set
 
 import boto3
-from loguru import logger
 from mypy_boto3_ssm import SSMClient
 from mypy_boto3_ssm.type_defs import ParameterStringFilterTypeDef
 
+from acat.logger import logger
 from acat.ssm.types import Parameter
 
 MATCH_STR = r"\{\{ ?resolve:ssm:\/\$\{AWS::StackName\}(\/.+) ?\}\+?\}"

--- a/src/acat/ssm/utils.py
+++ b/src/acat/ssm/utils.py
@@ -48,7 +48,10 @@ def get_ssm_parameter_names(path_preffix: str) -> set[str]:
 
     while True:
         logger.debug(f"Getting parameters page {i:02d}")
-        args = {"ParameterFilters": parameter_filters}
+        args = {
+            "MaxResults": 50,  # AWS maximum allowed value
+            "ParameterFilters": parameter_filters,
+        }
 
         if i > 1:
             # If it's not the first page, there is a response and a `NextToken`

--- a/tests/ssm/test_core.py
+++ b/tests/ssm/test_core.py
@@ -84,8 +84,25 @@ class TestCopy(BaseTest):
         assert result.exit_code == 1
         assert "Aborted" in result.output
 
-    def test_fail_without_providing_path_preffix(self):
+    def test_fail_without_providing_destination(self):
         result = self.runner.invoke(copy, ["/test1"])
 
         assert result.exit_code == 2
-        assert "Error: Missing argument 'DESTINATION'." in result.output
+        assert "Error: Missing argument 'DESTINATION'" in result.output
+
+    def test_success_replace(self, source="/test1", destination="/test2"):
+        # Assume the source parameters contain the string "old" in their value.
+        result = self.runner.invoke(
+            copy, [source, destination, "--replace", "s/old/new/"], input="y\n"
+        )
+
+        assert result.exit_code == 0
+        assert "Creating parameter:" in result.output
+
+    def test_fail_invalid_replace_format(self, source="/test1", destination="/test2"):
+        result = self.runner.invoke(
+            copy, [source, destination, "--replace", "invalidformat"], input="y\n"
+        )
+
+        assert result.exit_code == 1
+        assert "Invalid replace format" in result.output

--- a/tests/ssm/test_utils.py
+++ b/tests/ssm/test_utils.py
@@ -1,7 +1,12 @@
 import re
+import threading
 
+import boto3
+import click
 import pytest
 
+from acat.ssm.types import Parameter
+from acat.ssm.utils import create_ssm_parameters
 from acat.ssm.utils import get_current_params
 from acat.ssm.utils import get_ssm_parameter_names
 from acat.ssm.utils import get_ssm_parameters
@@ -88,3 +93,95 @@ class TestGetSsmParameters:
             ),
         ):
             get_ssm_parameters()  # type:ignore
+
+
+# Fake SSM client for testing
+class FakeSSMClient:
+    def __init__(self, raise_error=False):
+        self.put_param_calls = []
+        self.raise_error = raise_error
+        self.lock = threading.Lock()
+
+    def put_parameter(self, Overwrite, **parameter):
+        with self.lock:
+            if self.raise_error:
+                raise Exception("test error")
+            self.put_param_calls.append((Overwrite, parameter))
+
+
+@pytest.fixture()
+def fake_ssm_client(monkeypatch):
+    # This fixture allows tests to override the fake client behavior.
+    client_instance = FakeSSMClient()
+
+    def fake_client(service_name, *args, **kwargs):
+        if service_name == "ssm":
+            return client_instance
+        return boto3.client(service_name, *args, **kwargs)
+
+    monkeypatch.setattr(boto3, "client", fake_client)
+    return client_instance
+
+
+@pytest.fixture
+def captured_click_echo(monkeypatch):
+    messages = []
+
+    def fake_echo(message):
+        messages.append(message)
+
+    monkeypatch.setattr(click, "echo", fake_echo)
+    return messages
+
+
+def test_create_ssm_parameters_success(fake_ssm_client, captured_click_echo):
+    # create some fake parameters
+    parameters = [
+        Parameter(Name="/test/param1", Value="foo", Type="String"),
+        Parameter(Name="/test/param2", Value="bar", Type="String"),
+    ]
+    overwrite = True
+
+    create_ssm_parameters(parameters, overwrite)
+
+    # check that for each parameter, put_parameter was called and the echo message was printed
+    assert len(fake_ssm_client.put_param_calls) == len(parameters)
+
+    for call in fake_ssm_client.put_param_calls:
+        call_overwrite, call_param = call
+        assert call_overwrite is overwrite
+        # Check parameter dict contains proper keys
+        assert "Name" in call_param
+        assert "Value" in call_param
+        assert "Type" in call_param
+
+    # Check that each parameter creation was echoed
+    for param in parameters:
+        expected_message = f"Creating parameter: {param['Name']}"
+        assert expected_message in captured_click_echo
+
+
+def test_create_ssm_parameters_failure(monkeypatch, captured_click_echo):
+    # Set up a fake client which raises an error
+    fake_client = FakeSSMClient(raise_error=True)
+
+    def fake_ssm_client(service_name, *args, **kwargs):
+        if service_name == "ssm":
+            return fake_client
+        return boto3.client(service_name, *args, **kwargs)
+
+    monkeypatch.setattr(boto3, "client", fake_ssm_client)
+
+    parameters = [Parameter(Name="/test/param_error", Value="fail", Type="String")]
+    overwrite = False
+
+    # Should not raise despite failures; error messages should be echoed.
+    create_ssm_parameters(parameters, overwrite)
+
+    # In this case, since exception is caught, put_param_calls remains empty.
+    assert len(fake_client.put_param_calls) == 0
+
+    # Check that an error message was echoed
+    assert (
+        "Error creating parameter /test/param_error: test error" in captured_click_echo
+    )

--- a/tests/ssm/test_utils.py
+++ b/tests/ssm/test_utils.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from acat.ssm.utils import get_current_params
@@ -15,18 +17,22 @@ class TestGetCurrentParams:
             assert param.startswith(path_preffix)
 
     def test_fail_template_file_invalid_type(self, path_preffix="/test1"):
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(
+            ValueError,
+            match=re.escape("Template file must have .yaml or .yml extension"),
+        ):
             get_current_params("wrong_extension.txt", path_preffix)
-
-        assert str(exc_info.value) == "Template file must have .yaml or .yml extension"
 
     def test_fail_template_file_not_found(
         self, missing_template: str, path_preffix="/test1"
     ):
-        with pytest.raises(FileNotFoundError) as exc_info:
+        with pytest.raises(
+            FileNotFoundError,
+            match=re.escape(
+                f"[Errno 2] No such file or directory: '{missing_template}'"
+            ),
+        ):
             get_current_params(missing_template, path_preffix)
-
-        assert str(exc_info.value) == f"[Errno 2] No such file or directory: '{missing_template}'"  # noqa E501 # fmt: skip
 
     def test_fail_template_file_invalid_content(
         self, template_file_invalid_content: str, path_preffix="/test1"
@@ -51,10 +57,13 @@ class TestGetSsmParameterNames:
         assert len(names) == 0
 
     def test_fail_without_path_preffix(self):
-        with pytest.raises(TypeError) as exc_info:
+        with pytest.raises(
+            TypeError,
+            match=re.escape(
+                "get_ssm_parameter_names() missing 1 required positional argument: 'path_preffix'"  # noqa E501
+            ),
+        ):
             get_ssm_parameter_names()  # type:ignore
-
-        assert str(exc_info.value) == "get_ssm_parameter_names() missing 1 required positional argument: 'path_preffix'"  # noqa E501 # fmt: skip
 
 
 class TestGetSsmParameters:
@@ -72,7 +81,10 @@ class TestGetSsmParameters:
         assert len(params) == 0
 
     def test_fail_without_path_preffix(self):
-        with pytest.raises(TypeError) as exc_info:
+        with pytest.raises(
+            TypeError,
+            match=re.escape(
+                "get_ssm_parameters() missing 1 required positional argument: 'path_preffix'"  # noqa E501
+            ),
+        ):
             get_ssm_parameters()  # type:ignore
-
-        assert str(exc_info.value) == "get_ssm_parameters() missing 1 required positional argument: 'path_preffix'"  # noqa E501 # fmt: skip

--- a/tests/ssm/test_utils.py
+++ b/tests/ssm/test_utils.py
@@ -102,7 +102,7 @@ class FakeSSMClient:
         self.raise_error = raise_error
         self.lock = threading.Lock()
 
-    def put_parameter(self, Overwrite, **parameter):
+    def put_parameter(self, Overwrite, **parameter):  # noqa N803
         with self.lock:
             if self.raise_error:
                 raise Exception("test error")
@@ -144,7 +144,8 @@ def test_create_ssm_parameters_success(fake_ssm_client, captured_click_echo):
 
     create_ssm_parameters(parameters, overwrite)
 
-    # check that for each parameter, put_parameter was called and the echo message was printed
+    # Check that for each parameter, 'put_parameter' was called and the echo
+    # message was printed
     assert len(fake_ssm_client.put_param_calls) == len(parameters)
 
     for call in fake_ssm_client.put_param_calls:

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "acat"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
# Enhanced AWS SSM Parameter Management in ACAT v0.4.0

This PR introduces significant improvements to the SSM parameter management functionality in the AWS toolkit:

## Major Changes

- **Performance Boost**: Added parallel processing for SSM parameter operations, significantly improving performance when working with large numbers of parameters
- **New Replace Feature**: Added a `--replace` option to the `copy` command that allows modifying parameter values using regular expressions during copy
- **Default Log Level**: Changed default log level from WARNING to INFO for better visibility

## Technical Improvements

- Implemented concurrent fetching of SSM parameters using ThreadPoolExecutor
- Created utility function `create_ssm_parameters` for parallel parameter creation
- Added MaxResults parameter (50) when fetching parameter names for better pagination
- Improved error handling for parameter operations
- Unified logger imports across modules
- Added comprehensive tests for new functionality

## Bug Fixes

- Fixed error message assertions in tests
- Improved thread safety with locks when interacting with AWS API

## Version

- Bumped version from 0.3.0 to 0.4.0